### PR TITLE
Setup GitHub workflow for code formatting

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -58,9 +58,11 @@ jobs:
         continue-on-error: true
 
       - name: Format TOML files with Tombi
-        run: |
-          tombi fmt Cargo.toml
-          tombi fmt extension.toml
+        run: tombi fmt **/*.toml
+        continue-on-error: true
+
+      - name: Lint TOML files with Tombi
+        run: tombi lint **/*.toml
         continue-on-error: true
 
       - name: Check for changes

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,78 @@
+name: Auto Format & Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master, main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format-and-lint:
+    name: Auto Format & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup Tombi
+        uses: tombi-toml/setup-tombi@v1
+        with:
+          version: latest
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run cargo fmt
+        run: cargo fmt --all
+
+      - name: Run cargo clippy --fix
+        run: cargo clippy --fix --all-targets --allow-dirty --allow-staged
+        continue-on-error: true
+
+      - name: Format TOML files with Tombi
+        run: |
+          tombi fmt Cargo.toml
+          tombi fmt extension.toml
+        continue-on-error: true
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add -A
+          git commit -m "style: auto-format code with rustfmt, clippy, and tombi"
+          git push


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically format and lint code on pull requests targeting the `master` or `main` branches. The workflow ensures code quality by running formatting and linting tools for both Rust and TOML files, and can automatically commit and push any formatting fixes.

**Continuous Integration and Code Quality Automation:**

* Added `.github/workflows/auto-format.yml` to run on pull requests, which:
  * Checks out the PR branch and installs Rust (with `rustfmt` and `clippy`) and Tombi for TOML files.
  * Caches Rust dependencies and build artifacts to speed up workflow execution.
  * Runs `cargo fmt` for Rust code formatting and `cargo clippy --fix` for linting and auto-fixing Rust code issues.
  * Formats and lints all TOML files using Tombi.
  * Detects changes after formatting/linting, and if any are found, automatically commits and pushes them back to the PR branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated code formatting and linting workflow for pull requests to ensure consistent code quality and style standards across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->